### PR TITLE
Update max_id before adding bookmarks

### DIFF
--- a/crates/pdfcat/src/merge/merger.rs
+++ b/crates/pdfcat/src/merge/merger.rs
@@ -220,6 +220,7 @@ impl Merger {
 
             // Add all objects from doc to merged
             merged.objects.extend(doc.objects);
+            merged.max_id = max_id;
 
             // Update the page tree
             self.add_pages_to_tree(&mut merged, &doc_pages)?;


### PR DESCRIPTION
Right now, if you add bookmarks via `--bookmarks` the added objects can get ids of already existing objects. This results in mangled output pdfs. This fixes this.

Also worth thinking about: Maybe we should not make it possible to leave the Document struct in an invalid state. We could wrap the extending of the Object list in a method of the struct, updating the `self.max_id` member variable accordingly.