### PR TITLE
Implement bookmarks to start of each merged document

### DIFF
--- a/crates/pdfcat/src/merge/bookmarks.rs
+++ b/crates/pdfcat/src/merge/bookmarks.rs
@@ -44,7 +44,12 @@ impl BookmarkManager {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn add_bookmarks_for_files(&self, doc: &mut Document, file_paths: &[&Path]) -> Result<()> {
+    pub fn add_bookmarks_for_files(
+        &self,
+        doc: &mut Document,
+        file_paths: &[&Path],
+        page_starts: &[ObjectId],
+    ) -> Result<()> {
         if file_paths.is_empty() {
             return Ok(());
         }
@@ -78,7 +83,11 @@ impl BookmarkManager {
                 .and_then(|n| n.to_str())
                 .unwrap_or("Unknown");
 
-            let page_id = pages[page_idx].1;
+            let page_id = if let Some(&id) = page_starts.get(file_idx) {
+                id
+            } else {
+                pages[page_idx].1
+            };
 
             outline_items.push((title.to_string(), page_id));
         }
@@ -243,7 +252,7 @@ mod tests {
         let mut doc = create_test_document_with_pages(5);
         let manager = BookmarkManager::new();
 
-        let result = manager.add_bookmarks_for_files(&mut doc, &[]);
+        let result = manager.add_bookmarks_for_files(&mut doc, &[], &[]);
         assert!(result.is_ok());
     }
 
@@ -255,7 +264,7 @@ mod tests {
         let path = PathBuf::from("test.pdf");
         let paths = vec![path.as_path()];
 
-        let result = manager.add_bookmarks_for_files(&mut doc, &paths);
+        let result = manager.add_bookmarks_for_files(&mut doc, &paths, &[]);
         assert!(result.is_ok());
         assert!(manager.has_bookmarks(&doc));
     }
@@ -272,7 +281,7 @@ mod tests {
         ];
         let path_refs: Vec<&Path> = paths.iter().map(|p| p.as_path()).collect();
 
-        let result = manager.add_bookmarks_for_files(&mut doc, &path_refs);
+        let result = manager.add_bookmarks_for_files(&mut doc, &path_refs, &[]);
         assert!(result.is_ok());
         assert!(manager.has_bookmarks(&doc));
     }
@@ -293,7 +302,9 @@ mod tests {
         let path = PathBuf::from("test.pdf");
         let paths = vec![path.as_path()];
 
-        manager.add_bookmarks_for_files(&mut doc, &paths).unwrap();
+        manager
+            .add_bookmarks_for_files(&mut doc, &paths, &[])
+            .unwrap();
         assert!(manager.has_bookmarks(&doc));
 
         let result = manager.remove_bookmarks(&mut doc);

--- a/crates/pdfcat/src/merge/bookmarks.rs
+++ b/crates/pdfcat/src/merge/bookmarks.rs
@@ -40,7 +40,7 @@ impl BookmarkManager {
     /// # fn example(mut doc: Document) -> Result<(), Box<dyn std::error::Error>> {
     /// let manager = BookmarkManager::new();
     /// let paths = vec![Path::new("file1.pdf"), Path::new("file2.pdf")];
-    /// manager.add_bookmarks_for_files(&mut doc, &paths)?;
+    /// manager.add_bookmarks_for_files(&mut doc, &paths, &[])?;
     /// # Ok(())
     /// # }
     /// ```

--- a/crates/pdfcat/src/merge/merger.rs
+++ b/crates/pdfcat/src/merge/merger.rs
@@ -186,9 +186,13 @@ impl Merger {
         let mut merged = loaded_pdfs[0].document.clone();
         let mut max_id = merged.max_id;
 
+        let mut page_starts = vec![];
         // Process first document for page ranges
         if let Some(ref page_range) = config.page_range {
             merged = self.page_extractor.extract_pages(&merged, page_range)?;
+        }
+        if let Some(page_id) = merged.page_iter().nth(0) {
+            page_starts.push(page_id);
         }
 
         // Apply rotation to first document if specified
@@ -215,6 +219,10 @@ impl Merger {
             doc.renumber_objects_with(max_id + 1);
             max_id = doc.max_id;
 
+            if let Some(page_id) = doc.page_iter().nth(0) {
+                page_starts.push(page_id);
+            }
+
             // Get page references from the document
             let doc_pages: Vec<ObjectId> = doc.get_pages().into_values().collect();
 
@@ -232,8 +240,11 @@ impl Merger {
                 .iter()
                 .map(|p| p.path.as_path())
                 .collect::<Vec<_>>();
-            self.bookmark_manager
-                .add_bookmarks_for_files(&mut merged, file_paths.as_slice())?;
+            self.bookmark_manager.add_bookmarks_for_files(
+                &mut merged,
+                file_paths.as_slice(),
+                page_starts.as_slice(),
+            )?;
         }
 
         // Set metadata if specified


### PR DESCRIPTION
- changed the function definition of `BookmarkManager::add_bookmarks_for_files` to include a slice of `ObjectId`s to the start of each page
- on error ( I don't think this ever happens) on getting the Id for the page, fall back to old implementation
- might need better error handling: What happens here if a to be merged subset of a document is 0 pages long
  - maybe consider defaulting to last page id on `None`

should fix #32 